### PR TITLE
Fix: Catching Throwable instead of Exception in the Runnable

### DIFF
--- a/src/main/scala/com/qmetric/penfold/app/schedule/Scheduler.scala
+++ b/src/main/scala/com/qmetric/penfold/app/schedule/Scheduler.scala
@@ -25,7 +25,7 @@ trait Scheduler {
 
           logger.debug(s"scheduled $name completed")
         } catch {
-          case e: Exception => logger.error(s"error during scheduled $name", e)
+          case e: Throwable => logger.error(s"error during scheduled $name", e)
         }
       }
     }, 0, frequency.length, frequency.unit)

--- a/src/test/scala/com/qmetric/penfold/app/schedule/TaskTriggerSchedulerTest.scala
+++ b/src/test/scala/com/qmetric/penfold/app/schedule/TaskTriggerSchedulerTest.scala
@@ -1,17 +1,47 @@
 package com.qmetric.penfold.app.schedule
 
+import java.util.concurrent.TimeUnit
+
 import com.qmetric.penfold.command.CommandDispatcher
 import com.qmetric.penfold.readstore.{ReadStore, TaskProjectionReference}
 import org.specs2.mock.Mockito
+import org.mockito.Mockito._
 import org.specs2.mutable.SpecificationWithJUnit
 
+import scala.concurrent.duration.FiniteDuration
+
 class TaskTriggerSchedulerTest extends SpecificationWithJUnit with Mockito {
-  "periodically trigger future tasks" in {
+  "trigger future tasks" in {
     val readStore = mock[ReadStore]
     val commandDispatcher = mock[CommandDispatcher]
 
     new TaskTriggerScheduler(readStore, commandDispatcher, null).process()
 
     there was one(readStore).forEachTriggeredTask(any[TaskProjectionReference => Unit])
+  }
+
+  "periodically trigger future tasks even in the case of error" in {
+    val brokenReadStore = createBrokenReadStore()
+    val commandDispatcher = mock[CommandDispatcher]
+
+    val scheduler: TaskTriggerScheduler = new TaskTriggerScheduler(
+      brokenReadStore, commandDispatcher, new FiniteDuration(10, TimeUnit.MILLISECONDS))
+
+    scheduler.start()
+    waitLongEnoughSoThatGivenDurationPassesAtLeastTimes(scheduler.frequency, 3)
+
+    there were atLeastThree(brokenReadStore).forEachTriggeredTask(any[TaskProjectionReference => Unit])
+  }
+
+  private def waitLongEnoughSoThatGivenDurationPassesAtLeastTimes(delay: FiniteDuration, howManyTimes: Int): Unit = {
+    def warmUpTimeInMilliseconds = 500
+    Thread.sleep(warmUpTimeInMilliseconds + (delay.toMillis * howManyTimes))
+  }
+
+  private def createBrokenReadStore(): ReadStore = {
+    val readStore = mock[ReadStore]
+    when(readStore.forEachTriggeredTask(any[TaskProjectionReference => Unit])).thenThrow(new Error())
+
+    readStore
   }
 }


### PR DESCRIPTION
Fix: Catching Throwable instead of Exception in the Runnable passed to the scheduleAtFixedRate method invoked in the Scheduler.

According to the https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ScheduledExecutorService.html , "If any execution of the task encounters an exception, subsequent executions are suppressed."
In case of an Error (as opposed to Exception) the scheduler used to stop working, as Error does not extend Exception, but Throwable. Now it will carry on.